### PR TITLE
Fix timestamp tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,7 @@ jobs:
 
           # Rolling release tag
           if [ ${{ steps.setenv.outputs.TAG_PUSH }} == "false" ]; then \
-            TAG_DATE="$( date +"%Y-%m-%d" )"; \
+            TAG_DATE="$( date +"%Y-%m-%dT%H%M%S" )"; \
             TAG_VERSION="$( echo "${{ steps.docker.outputs.VERSION_TAG }}" | cut -d '-' -f2- )"; \
             TAG_NAME="${TAG_NAME}-nightly-${TAG_DATE}-${TAG_VERSION}"; \
           fi


### PR DESCRIPTION
https://github.com/V-Sekai/v-sekai-game/pull/489
Add hour/minute/seconds to avoid tag name collisions on rebuilds.